### PR TITLE
Revamp roast UI styling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,12 @@
+import type { FormEvent } from 'react';
 import { useState } from 'react';
+
+const ideaPrompts = [
+  '내가 쓴 자소서 좀 꼬집어줘',
+  '밤새 만든 PPT 한 번 깔아줘',
+  '내가 한 말투 좀 디스해줘',
+  '팀 프로젝트 PR 리뷰처럼 날카롭게',
+];
 
 function App() {
   const [text, setText] = useState('');
@@ -6,7 +14,7 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!text.trim()) return;
 
@@ -40,65 +48,79 @@ function App() {
     }
   };
 
+  const disabled = loading || !text.trim();
+
   return (
-    <div
-      style={{
-        maxWidth: 600,
-        margin: '40px auto',
-        padding: '24px',
-        borderRadius: 12,
-        border: '1px solid #ddd',
-        fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
-      }}
-    >
-      <h1 style={{ fontSize: 24, marginBottom: 16 }}>AI 악담(장난) 머신 ㅎㅎ</h1>
-      <p style={{ fontSize: 14, color: '#666', marginBottom: 16 }}>
-        한 문장을 적으면, AI가 가볍게 디스해줍니다. 진지한 용도로 쓰지 말 것 😇
-      </p>
+    <div className="page">
+      <div className="page__glow" aria-hidden />
+      <main className="card">
+        <div className="eyebrow">Roast Playground</div>
+        <h1 className="title">AI 악담(장난) 머신</h1>
+        <p className="subtitle">
+          한 문장을 적으면, AI가 가볍게 디스해줍니다. 장난스럽게 받아들이고 웃어넘겨주세요 😇
+        </p>
 
-      <form onSubmit={handleSubmit}>
-        <textarea
-          rows={3}
-          style={{ width: '100%', padding: 8, resize: 'vertical' }}
-          placeholder="여기에 문장을 적어보세요"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
-        <button
-          type="submit"
-          disabled={loading || !text.trim()}
-          style={{
-            marginTop: 12,
-            padding: '8px 16px',
-            borderRadius: 8,
-            border: 'none',
-            backgroundColor: loading || !text.trim() ? '#ccc' : '#007bff',
-            color: '#fff',
-            cursor: loading || !text.trim() ? 'default' : 'pointer',
-          }}
-        >
-          {loading ? '생각 중…' : '디스해줘 ㅋㅋ'}
-        </button>
-      </form>
-
-      {error && <p style={{ marginTop: 16, color: 'red' }}>{error}</p>}
-
-      {roast && (
-        <div
-          style={{
-            marginTop: 24,
-            padding: 16,
-            borderRadius: 8,
-            backgroundColor: '#f0f0f0',
-            color: '#222',
-          }}
-        >
-          <div style={{ fontSize: 14, color: '#555', marginBottom: 8 }}>
-            AI의 부정적인 피드백 😈
-          </div>
-          <div style={{ color: '#222' }}>{roast}</div>
+        <div className="chip-row" role="list">
+          {ideaPrompts.map((prompt) => (
+            <button
+              key={prompt}
+              type="button"
+              className="chip"
+              onClick={() => {
+                setText(prompt);
+                setRoast('');
+                setError('');
+              }}
+              disabled={loading}
+              role="listitem"
+            >
+              {prompt}
+            </button>
+          ))}
         </div>
-      )}
+
+        <form onSubmit={handleSubmit} className="form">
+          <label htmlFor="roast-text" className="label">
+            뭘 디스하고 싶은가요?
+            <span className="label__hint">짧을수록 더 독하게 돌아올지도 몰라요</span>
+          </label>
+          <div className="textarea-shell">
+            <textarea
+              id="roast-text"
+              rows={4}
+              maxLength={280}
+              className="textarea"
+              placeholder="여기에 문장을 적어보세요"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+            />
+            <div className="textarea__footer">
+              <span className="muted">최대 280자</span>
+              <span className="counter">{text.length}자</span>
+            </div>
+          </div>
+
+          <div className="actions">
+            <div className="status">
+              {error ? (
+                <span className="status__error">{error}</span>
+              ) : (
+                <span className="status__info">AI가 가볍게 놀릴 준비 완료 🎯</span>
+              )}
+            </div>
+            <button type="submit" className="primary" disabled={disabled}>
+              {loading ? 'AI가 생각 중…' : '디스해줘 ㅋㅋ'}
+            </button>
+          </div>
+        </form>
+
+        {roast && (
+          <section className="result" aria-live="polite">
+            <div className="badge">AI의 부정적인 피드백 😈</div>
+            <p className="result__text">{roast}</p>
+          </section>
+        )}
+      </main>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,281 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  color: #0f172a;
+  background-color: #0b1021;
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.15), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.2), transparent 30%),
+    radial-gradient(circle at 50% 80%, rgba(16, 185, 129, 0.18), transparent 35%), #0b1021;
+  color: #0f172a;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.page {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 20px 48px;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
+.page__glow {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.06), transparent 35%),
+    radial-gradient(circle at 70% 40%, rgba(255, 255, 255, 0.04), transparent 30%);
+  filter: blur(60px);
+  z-index: 0;
+}
+
+.card {
+  position: relative;
+  z-index: 1;
+  width: min(960px, 100%);
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 24px;
+  padding: 32px 32px 28px;
+  box-shadow: 0 15px 50px rgba(15, 23, 42, 0.15);
+  backdrop-filter: blur(8px);
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.1), rgba(14, 165, 233, 0.1));
+  color: #4338ca;
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.title {
+  margin: 12px 0 8px;
+  font-size: clamp(26px, 3vw, 32px);
+  color: #0f172a;
+}
+
+.subtitle {
+  margin: 0 0 20px;
+  color: #475569;
+  max-width: 760px;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.chip {
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: rgba(99, 102, 241, 0.08);
+  color: #312e81;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-weight: 600;
+  font-size: 14px;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    border-color 0.12s ease;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+.chip:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(99, 102, 241, 0.15);
+  border-color: rgba(99, 102, 241, 0.8);
+}
+
+.chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.label__hint {
+  font-weight: 500;
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.textarea-shell {
+  background: #f8fafc;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 12px 12px 6px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.textarea {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1.6;
+  background: transparent;
+  color: #0f172a;
+}
+
+.textarea::placeholder {
+  color: #94a3b8;
+}
+
+.textarea__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 6px;
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.counter {
+  font-weight: 700;
+  color: #4338ca;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.status {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status__info {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.status__error {
+  color: #dc2626;
+  font-weight: 700;
+}
+
+.primary {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 18px;
+  font-weight: 700;
+  font-size: 16px;
+  color: #f8fafc;
+  background: linear-gradient(135deg, #6366f1, #22d3ee);
+  box-shadow: 0 10px 30px rgba(79, 70, 229, 0.3);
+  cursor: pointer;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    filter 0.12s ease;
+}
+
+.primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 36px rgba(34, 211, 238, 0.28);
+  filter: brightness(1.02);
+}
+
+.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.result {
+  margin-top: 22px;
+  padding: 16px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(99, 102, 241, 0.08), rgba(59, 130, 246, 0.06));
+  border: 1px solid rgba(99, 102, 241, 0.25);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(67, 56, 202, 0.12);
+  color: #3730a3;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.result__text {
+  margin: 12px 0 0;
+  color: #0f172a;
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.muted {
+  color: #94a3b8;
+}
+
+@media (max-width: 720px) {
+  .card {
+    padding: 24px;
   }
-  a:hover {
-    color: #747bff;
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
   }
-  button {
-    background-color: #f9f9f9;
+
+  .primary {
+    width: 100%;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the roast interface with a card layout, prompt chips, and clearer status messaging
- add guided textarea experience with character counter and improved button states
- refresh global styling with gradient background, new typography, and responsive spacing

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934f056debc832f92692c3774ee643a)