### PR TITLE
Migrate frontend deployment from GitHub Pages to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,4 +1,4 @@
-name: Deploy Frontend to GitHub Pages
+name: Deploy Frontend to Cloudflare Pages
 
 on:
   push:
@@ -9,7 +9,8 @@ on:
       - ".github/workflows/deploy-frontend.yml"
 
 permissions:
-  contents: write
+  contents: read
+  deployments: write
 
 jobs:
   build-and-deploy:
@@ -23,11 +24,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -39,9 +35,11 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        run: |
-          npm install -D gh-pages
-          npx gh-pages -d dist -r "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: my-roast-app
+          directory: frontend/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,14 +3,11 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://kongsungeui.github.io/my-roast-app",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
   const proxyTarget = env.VITE_PROXY_TARGET || 'http://localhost:4000';
 
   return {
-    base: '/my-roast-app/',
+    base: '/',
     plugins: [react()],
     server: {
       proxy: {


### PR DESCRIPTION
- Update GitHub Actions workflow to use cloudflare/pages-action
- Remove GitHub Pages specific settings (homepage, deploy scripts)
- Change vite base path from '/my-roast-app/' to '/' for root deployment
- Update permissions to support Cloudflare Pages deployment

fixes #4 
